### PR TITLE
README: update stewart's email address

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ GPLv3+ - see LICENSE file.
 CONTRIBUTING
 ============
 
-Send patches to stewart@linux.ibm.com or use a GitHub Pull request.
+Send patches to stewart@flamingspork.com or use a GitHub Pull request.
 
 Please ensure all contributions follow Developer Certificate of Origin:
 


### PR DESCRIPTION
Sadly, Stewart no longer works with the IBM-employed division of
Australia's greatest kernel team, and while once an OzLabber, always an
OzLabber, when one ceases to be an IBM employee the @linux.ibm.com email
disappears with it.

Update it to Stewart's personal email.

Signed-off-by: Andrew Donnellan <andrew@donnellan.id.au>